### PR TITLE
Add smoke test suite and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  unit-tests:
+    name: Unit Tests (Vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm test -- --run
+
+  e2e-tests:
+    name: E2E Tests (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      # Install Chromium and its Linux system dependencies.
+      # --with-deps handles apt packages (libglib2.0, libnss3, etc.) so the
+      # headless shell can run on a clean Ubuntu runner.
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - run: npm run test:e2e
+
+      # Upload the HTML report as an artifact so you can inspect failures
+      # without re-running the workflow.
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ dist-ssr
 build
 *.local
 
+# Playwright
+test-results/
+playwright-report/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/e2e/regression.spec.ts
+++ b/e2e/regression.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Production-like regression tests using a real Chromium browser.
+ *
+ * Unlike the Vitest/jsdom tests that must mock DataGrid internals to work
+ * around jsdom's lack of a CSS layout engine, these tests run against the
+ * actual app in a headless browser.  DataGrid's layout, virtualisation,
+ * cell-edit lifecycle, and DOM event handling all behave exactly as they
+ * do for real users, so no mocking of MUI internals is required.
+ *
+ * The primary regression being guarded:
+ *   @mui/x-data-grid versions immediately after 6.18.2 introduced a bug where
+ *   committing a cell edit only re-rendered the edited row; sibling rows kept
+ *   stale computed values.  These tests will catch that regression by
+ *   asserting that calculated fields on OTHER rows update after an edit.
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns a locator for the data row whose Fund Name cell contains `name`. */
+function fundRow(page: Page, name: string) {
+  return page.getByRole('row').filter({
+    has: page.locator(`[data-field="nameString"]:has-text("${name}")`),
+  });
+}
+
+/** Returns the Amount to Invest cell for a given fund row. */
+function amountCell(page: Page, fundName: string) {
+  return fundRow(page, fundName).locator('[data-field="amountToInvestString"]');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('DataGrid regression: editing one row must update all rows', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    // Wait until both default fund rows are visible before each test
+    await fundRow(page, 'VFIAX').waitFor();
+    await fundRow(page, 'VTSAX').waitFor();
+  });
+
+  test('initial render shows correct default calculated values', async ({ page }) => {
+    // Default: invest $100, VFIAX balance=$100 / target=40%, VTSAX balance=$100 / target=60%
+    // VFIAX gap to target: target $160 in $400 total... wait: no build step, using initial values
+    // With $100 total balance and $100 to invest: VFIAX target 40% → $160 future on $200 total
+    // VFIAX gap = $60, VTSAX gap = $140; total gap = $200 > $100 so proportional fill
+    // Actually with balance=$100 each, invest=$100: total future=$300
+    // VFIAX target 40% of $300 = $120; current $100; gap = $20
+    // VTSAX target 60% of $300 = $180; current $100; gap = $80
+    // Total gap = $100 = amount to invest → VFIAX gets $20, VTSAX gets $80
+    await expect(amountCell(page, 'VFIAX')).toContainText('$20.00');
+    await expect(amountCell(page, 'VTSAX')).toContainText('$80.00');
+  });
+
+  /**
+   * CRITICAL REGRESSION TEST — no mocking required.
+   *
+   * This is the same scenario as the Vitest `simulateCellCommit` test but
+   * exercises the full DataGrid cell-edit flow in a real browser:
+   *   double-click → edit input → type → Enter to commit → processRowUpdate fires
+   *   → React state updates → DataGrid re-renders ALL rows from new `rows` prop.
+   *
+   * A buggy DataGrid version will pass the first assertion (edited row updates)
+   * but fail the second (sibling row stays stale).
+   */
+  test('editing VFIAX balance updates calculated fields in OTHER rows (regression)', async ({ page }) => {
+    const balanceCell = fundRow(page, 'VFIAX').locator('[data-field="currentBalanceString"]');
+
+    // Single click to focus/select the cell — does NOT enter edit mode yet.
+    await balanceCell.click();
+
+    // Pressing a printable key on a focused DataGrid cell calls
+    //   startCellEditMode({ id, field, deleteValue: true, initialValue: '2' })
+    // DataGrid enters edit mode with the old value cleared and '2' as the
+    // initial character.  No intermediate empty-string state means no
+    // validation error that would cause Tab to revert to the old value.
+    await page.keyboard.press('2');
+
+    // Wait for the edit-mode input to appear before typing further characters.
+    // page.keyboard.type() dispatches events before React can re-render the
+    // new input element, so '0' and '0' would be missed.  Waiting for the
+    // input element and then calling type() on it directly is reliable.
+    const editInput = balanceCell.locator('input');
+    await editInput.waitFor({ state: 'visible' });
+
+    // Append the remaining digits directly on the input element
+    await editInput.type('00');
+
+    // DataGrid v6's GridEditInputCell debounces setEditCellValue() by 200ms
+    // in its onChange handler.  If Tab fires before the debounce resolves,
+    // stopCellEditMode reads the stale pre-edit value from React state and
+    // calls processRowUpdate with the OLD balance.  Waiting 250ms lets the
+    // debounce fire so React state reflects '200' before we commit.
+    await expect(editInput).toHaveValue('200');
+    await page.waitForTimeout(250);
+
+    // Tab commits the edit (triggers processRowUpdate) and moves focus away
+    await editInput.press('Tab');
+
+    // The edited row (VFIAX) is now over-target:
+    //   total balance = $300, invest = $100, total future = $400
+    //   VFIAX target 40% of $400 = $160 < current $200 → over-target → gets $0
+    await expect(amountCell(page, 'VFIAX')).toContainText('$0.00');
+
+    // THE CRITICAL ASSERTION — this is what the buggy version fails:
+    //   VTSAX target 60% of $400 = $240; current $100; gap = $140 > $100
+    //   VTSAX gets the full remaining $100 to invest.
+    await expect(amountCell(page, 'VTSAX')).toContainText('$100.00');
+  });
+
+  test('add fund button inserts a new editable row', async ({ page }) => {
+    await page.getByRole('button', { name: /add fund/i }).click();
+    await expect(page.getByRole('row').filter({ hasText: 'New Fund' })).toBeVisible();
+  });
+
+  test('delete button removes the fund row', async ({ page }) => {
+    // The delete action renders as a menuitem inside the actions cell
+    const actionsCell = fundRow(page, 'VFIAX').locator('[data-field="actions"]');
+    await actionsCell.getByRole('menuitem').click();
+
+    await expect(fundRow(page, 'VFIAX')).not.toBeVisible();
+    await expect(fundRow(page, 'VTSAX')).toBeVisible();
+  });
+
+  test('changing the investment amount updates all fund rows', async ({ page }) => {
+    const investmentInput = page.getByLabel(/investment amount/i);
+    await investmentInput.fill('200');
+
+    // With balance=$100 each and $200 to invest:
+    //   total future = $400; VFIAX target $160 gap=$60; VTSAX target $240 gap=$140
+    //   total gap = $200 = amount to invest → VFIAX gets $60, VTSAX gets $140
+    await expect(amountCell(page, 'VFIAX')).toContainText('$60.00');
+    await expect(amountCell(page, 'VTSAX')).toContainText('$140.00');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.11.1",
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.1",
         "@testing-library/user-event": "^14.5.2",
@@ -1631,6 +1632,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -5687,6 +5704,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "test": "vitest",
+    "test:e2e": "playwright test",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -26,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.5.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright E2E config — runs against the Vite dev server in a real headless
+ * Chromium instance.  This supplements the Vitest/jsdom unit & integration
+ * tests with genuine browser-level tests where MUI DataGrid's layout engine,
+ * event system, and cell-edit lifecycle all work exactly as they do in
+ * production.
+ *
+ * Why Playwright instead of jsdom for DataGrid interaction tests:
+ *   https://github.com/mui/mui-x/issues/15825 — MUI maintainer recommends
+ *   using an actual headless browser (Cypress/Playwright) for DataGrid tests
+ *   because jsdom lacks the layout engine that DataGrid relies on.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  /* Fail fast on CI if a test is accidentally left with `.only` */
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: 'http://localhost:5174',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    /* Use a dedicated port so this doesn't clash with the normal dev server */
+    command: 'npx vite --port 5174',
+    url: 'http://localhost:5174',
+    /* On CI always start a fresh server; locally reuse one if already running */
+    reuseExistingServer: !process.env.CI,
+    /* Suppress auto-open browser tab from vite.config server.open:true */
+    env: { BROWSER: 'none' },
+    stdout: 'ignore',
+    stderr: 'pipe',
+    timeout: 60_000,
+  },
+});

--- a/src/calculator/Calculator.test.ts
+++ b/src/calculator/Calculator.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'vitest';
+import Big from 'big.js';
+import calculate from './Calculator';
+
+// Helper to build a CalcFundItem-compatible object (FundInputItem shape)
+function fund(currentBalance: string, targetPercent: string) {
+  return {
+    internalId: 0,
+    name: 'Fund',
+    currentBalance: new Big(currentBalance),
+    // targetPercent stored as decimal (0.40 = 40%)
+    targetPercent: new Big(targetPercent).div(100),
+  };
+}
+
+function toFixed(big: Big, decimals = 2) {
+  return big.toFixed(decimals);
+}
+
+describe('calculate()', () => {
+  test('default two-fund scenario: VFIAX $100/40% + VTSAX $100/60%, invest $100', () => {
+    const result = calculate({
+      amountToInvest: new Big('100'),
+      fundInputItems: [fund('100', '40'), fund('100', '60')],
+    });
+
+    const [vfiax, vtsax] = result.outputItems;
+
+    // VFIAX is at 50% current, target 40% — over target, gets the smaller share
+    expect(toFixed(vfiax.amountToInvest)).toBe('20.00');
+    expect(toFixed(vtsax.amountToInvest)).toBe('80.00');
+
+    expect(toFixed(vfiax.balanceAfter)).toBe('120.00');
+    expect(toFixed(vtsax.balanceAfter)).toBe('180.00');
+
+    // percentAfter should be close to target (40% / 60%)
+    expect(vfiax.percentAfter.toFixed(4)).toBe('0.4000');
+    expect(vtsax.percentAfter.toFixed(4)).toBe('0.6000');
+  });
+
+  test('amounts sum exactly to amountToInvest (rounding correctness)', () => {
+    // Three-fund split — common source of off-by-a-penny rounding errors
+    const result = calculate({
+      amountToInvest: new Big('100'),
+      fundInputItems: [fund('100', '33'), fund('100', '33'), fund('100', '34')],
+    });
+
+    const total = result.outputItems.reduce(
+      (acc, item) => acc.plus(item.amountToInvest),
+      new Big('0')
+    );
+
+    expect(toFixed(total)).toBe('100.00');
+  });
+
+  test('fund already over target: gets $0, rest fills the other', () => {
+    // VFIAX balance=200, target=40% — already over target with invest=$100
+    // Total future = 200 + 100 + 100 = 400; 40% of 400 = 160 < 200 → VFIAX gets $0
+    const result = calculate({
+      amountToInvest: new Big('100'),
+      fundInputItems: [fund('200', '40'), fund('100', '60')],
+    });
+
+    const [vfiax, vtsax] = result.outputItems;
+
+    expect(toFixed(vfiax.amountToInvest)).toBe('0.00');
+    expect(toFixed(vtsax.amountToInvest)).toBe('100.00');
+  });
+
+  test('single fund: all investment goes to it', () => {
+    const result = calculate({
+      amountToInvest: new Big('500'),
+      fundInputItems: [fund('1000', '100')],
+    });
+
+    expect(toFixed(result.outputItems[0].amountToInvest)).toBe('500.00');
+    expect(toFixed(result.outputItems[0].balanceAfter)).toBe('1500.00');
+    expect(result.outputItems[0].percentAfter.toFixed(4)).toBe('1.0000');
+  });
+
+  test('empty fund list: returns empty outputItems', () => {
+    const result = calculate({
+      amountToInvest: new Big('100'),
+      fundInputItems: [],
+    });
+
+    expect(result.outputItems).toHaveLength(0);
+  });
+
+  test('target percentages sum > 100%: normalized proportionally', () => {
+    // Both at 80% → each effectively 50% after normalization
+    const result = calculate({
+      amountToInvest: new Big('100'),
+      fundInputItems: [fund('100', '80'), fund('100', '80')],
+    });
+
+    const [a, b] = result.outputItems;
+
+    // After normalization both targets are 50%; current is also 50% — split evenly
+    expect(toFixed(a.amountToInvest)).toBe('50.00');
+    expect(toFixed(b.amountToInvest)).toBe('50.00');
+  });
+
+  test('zero total current balance: no division-by-zero, splits by target', () => {
+    const result = calculate({
+      amountToInvest: new Big('100'),
+      fundInputItems: [fund('0', '40'), fund('0', '60')],
+    });
+
+    const [a, b] = result.outputItems;
+
+    expect(toFixed(a.amountToInvest)).toBe('40.00');
+    expect(toFixed(b.amountToInvest)).toBe('60.00');
+
+    // percentAfter should match target percents
+    expect(a.percentAfter.toFixed(4)).toBe('0.4000');
+    expect(b.percentAfter.toFixed(4)).toBe('0.6000');
+  });
+
+  test('zero amountToInvest: all funds get $0', () => {
+    const result = calculate({
+      amountToInvest: new Big('0'),
+      fundInputItems: [fund('100', '40'), fund('100', '60')],
+    });
+
+    for (const item of result.outputItems) {
+      expect(toFixed(item.amountToInvest)).toBe('0.00');
+    }
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,5 +15,6 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: './src/setupTests.ts',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
   }
 })


### PR DESCRIPTION
- Calculator.test.ts: 8 unit tests for pure calculator logic
- e2e/regression.spec.ts: 5 Playwright browser tests covering initial render, add/delete fund, investment amount changes, and the critical @mui/x-data-grid regression (editing one row must update all rows)
- playwright.config.ts: Playwright config targeting headless Chromium against the Vite dev server on port 5174
- .github/workflows/ci.yml: CI workflow running Vitest + Playwright on every pull request; Playwright report uploaded as artifact on failure
- vite.config.ts: scope Vitest include to src/ to exclude e2e/ folder
- package.json: add test:e2e script
- .gitignore: exclude test-results/ and playwright-report/